### PR TITLE
feat(account): migrate account/memory.js to TypeScript

### DIFF
--- a/src/account/base.ts
+++ b/src/account/base.ts
@@ -22,30 +22,29 @@
  * @export isAccountBase
  */
 
- import stampit from '@stamp/it'
- import { required } from '@stamp/required'
- // @ts-ignore
- import { messageToHash, verifyMessage as verifyMessageCrypto, hash } from '../utils/crypto'
- // @ts-ignore
- import { buildTx } from '../tx/builder'
- // @ts-ignore
- import { decode } from '../tx/builder/helpers'
- // @ts-ignore
- import { TX_TYPE } from '../tx/builder/schema'
- // @ts-ignore
- import { getNetworkId } from '../node'
- import { AccountBase } from './base.types'
- 
- 
- /**
+import stampit from '@stamp/it'
+import { required } from '@stamp/required'
+// @ts-ignore
+import { messageToHash, verifyMessage as verifyMessageCrypto, hash } from '../utils/crypto'
+// @ts-ignore
+import { buildTx } from '../tx/builder'
+// @ts-ignore
+import { decode } from '../tx/builder/helpers'
+// @ts-ignore
+import { TX_TYPE } from '../tx/builder/schema'
+// @ts-ignore
+import { getNetworkId } from '../node'
+import { AccountBase } from './base.types'
+
+/**
   * Check is provided object looks like an instance of AccountBase
   * @rtype (Object) => Boolean
   * @param {Object} acc - Object to check
   * @return {Boolean}
   */
- export const isAccountBase = (acc: AccountBase | any) => !['sign', 'address'].find(f => typeof acc[f] !== 'function')
- 
- /**
+export const isAccountBase = (acc: AccountBase | any) => !['sign', 'address'].find(f => typeof acc[f] !== 'function')
+
+/**
   * Sign encoded transaction
   * @instance
   * @category async
@@ -55,17 +54,17 @@
   * @param {Object} [opt.innerTx] - Sign as inner transaction for PayingFor
   * @return {String} Signed transaction
    */
- async function signTransaction(this: AccountBase, tx: Parameters<AccountBase['signTransaction']>[0], opt: Parameters<AccountBase['signTransaction']>[1] = {}) {
-   const prefixes = [this.getNetworkId(opt as Parameters<AccountBase['getNetworkId']>[0])]
-   if (opt.innerTx) prefixes.push('inner_tx')
-   const rlpBinaryTx = decode(tx, 'tx')
-   const txWithNetworkId = Buffer.concat([Buffer.from(prefixes.join('-')), hash(rlpBinaryTx)])
- 
-   const signatures = [await this.sign(txWithNetworkId, opt)]
-   return buildTx({ encodedTx: rlpBinaryTx, signatures }, TX_TYPE.signed).tx
- }
- 
- /**
+async function signTransaction (this: AccountBase, tx: Parameters<AccountBase['signTransaction']>[0], opt: Parameters<AccountBase['signTransaction']>[1] = {}) {
+  const prefixes = [this.getNetworkId(opt as Parameters<AccountBase['getNetworkId']>[0])]
+  if (opt.innerTx) prefixes.push('inner_tx')
+  const rlpBinaryTx = decode(tx, 'tx')
+  const txWithNetworkId = Buffer.concat([Buffer.from(prefixes.join('-')), hash(rlpBinaryTx)])
+
+  const signatures = [await this.sign(txWithNetworkId, opt)]
+  return buildTx({ encodedTx: rlpBinaryTx, signatures }, TX_TYPE.signed).tx
+}
+
+/**
   * Sign message
   * @instance
   * @category async
@@ -74,12 +73,12 @@
   * @param {Object} opt - Options
   * @return {String} Signature
   */
- async function signMessage(this:AccountBase, message: Parameters<AccountBase['signMessage']>[0], opt: Parameters<AccountBase['signMessage']>[1] = { returnHex: false }) {
-   const sig = await this.sign(messageToHash(message), opt)
-   return opt.returnHex ? Buffer.from(sig).toString('hex') : sig
- }
- 
- /**
+async function signMessage (this:AccountBase, message: Parameters<AccountBase['signMessage']>[0], opt: Parameters<AccountBase['signMessage']>[1] = { returnHex: false }) {
+  const sig = await this.sign(messageToHash(message), opt)
+  return opt.returnHex ? Buffer.from(sig).toString('hex') : sig
+}
+
+/**
   * Verify message
   * @instance
   * @category async
@@ -91,15 +90,15 @@
   * @param {Object} opt - Options
   * @return {Boolean}
   */
- async function verifyMessage(this:AccountBase,message: Parameters<AccountBase['verifyMessage']>[0], signature: Parameters<AccountBase['verifyMessage']>[1], opt: Parameters<AccountBase['verifyMessage']>[2] = {}) {
-   return verifyMessageCrypto(
-     message,
-     typeof signature === 'string' ? Buffer.from(signature, 'hex') : signature,
-     decode(await this.address(opt))
-   )
- }
- 
- /**
+async function verifyMessage (this:AccountBase, message: Parameters<AccountBase['verifyMessage']>[0], signature: Parameters<AccountBase['verifyMessage']>[1], opt: Parameters<AccountBase['verifyMessage']>[2] = {}) {
+  return verifyMessageCrypto(
+    message,
+    typeof signature === 'string' ? Buffer.from(signature, 'hex') : signature,
+    decode(await this.address(opt))
+  )
+}
+
+/**
   * AccountBase Stamp
   *
   * Attempting to create instances from the Stamp without overwriting all
@@ -115,18 +114,17 @@
   * @param {String} options.networkId - NETWORK_ID using for signing transaction's
   * @return {Object} Account instance
   */
- 
- export default stampit<AccountBase>({
- init(this: AccountBase, { networkId }) { // NETWORK_ID using for signing transaction's
-     if (!this.networkId && networkId) {
-       this.networkId = networkId
-     }
-   },
-   methods: { signTransaction, getNetworkId, signMessage, verifyMessage } as Omit<AccountBase, 'sign' | 'address'>
- }, required({
-   methods: {
-     sign: required,
-     address: required
-   } as Pick<AccountBase, 'sign' | 'address'>
- }) as stampit.Composable)
- 
+
+export default stampit<AccountBase>({
+  init (this: AccountBase, { networkId }) { // NETWORK_ID using for signing transaction's
+    if (!this.networkId && networkId) {
+      this.networkId = networkId
+    }
+  },
+  methods: { signTransaction, getNetworkId, signMessage, verifyMessage } as Omit<AccountBase, 'sign' | 'address'>
+}, required({
+  methods: {
+    sign: required,
+    address: required
+  } as Pick<AccountBase, 'sign' | 'address'>
+}) as stampit.Composable)

--- a/src/account/base.types.ts
+++ b/src/account/base.types.ts
@@ -1,3 +1,10 @@
+/**
+  * AccountBase
+  *
+  * Account is one of the three basic building blocks of an
+  * {@link module:@aeternity/aepp-sdk/es/ae--Ae} client and provides access to a
+  * signing key pair.
+  */
 export interface AccountBase {
     networkId: string
     readonly signTransaction: (tx: string, opt?: { innerTx?: boolean }) => Promise<string>
@@ -11,7 +18,8 @@ export interface AccountBase {
      */
     readonly getNetworkId: (opt?: { networkId?: string, force?: boolean }) => string
     readonly signMessage: (message: string, opt?: { returnHex?: boolean }) => Promise<string>
-    readonly verifyMessage: (message: string, signature: string, opt?: { onAccount?: object }) => Promise<boolean>
+    readonly verifyMessage: (message: string, signature: string,
+        opt?: { onAccount?: object }) => Promise<boolean>
 
     /**
      * Sign data blob
@@ -23,7 +31,7 @@ export interface AccountBase {
      * @param {String} data - Data blob to sign
      * @return {String} Signed data blob
      */
-    readonly sign: (data: string | Buffer, opt?: any) => Promise<string>
+    readonly sign: (data: string | Buffer, opt?: any) => Promise<Buffer|Uint8Array|String>
 
     /**
      * Obtain account address

--- a/src/account/memory.ts
+++ b/src/account/memory.ts
@@ -23,10 +23,14 @@
  */
 
 import AccountBase from './base'
+// @ts-ignore TODO: remove me
 import { sign, isValidKeypair } from '../utils/crypto'
 import { isHex } from '../utils/string'
+// @ts-ignore TODO: remove me
 import { decode } from '../tx/builder/helpers'
 import { InvalidKeypairError } from '../utils/errors'
+import { Memory } from './memory.types'
+import stampit from '@stamp/it'
 
 const secrets = new WeakMap()
 
@@ -42,7 +46,7 @@ const secrets = new WeakMap()
  * @return {Account}
  */
 export default AccountBase.compose({
-  init ({ keypair, gaId }) {
+  init (this:Memory, { keypair, gaId }: Memory['options']) {
     this.isGa = !!gaId
     if (gaId) {
       decode(gaId)
@@ -72,12 +76,12 @@ export default AccountBase.compose({
   },
   props: { isGa: false },
   methods: {
-    sign (data) {
+    sign (this:Memory, data) {
       if (this.isGa) throw new InvalidKeypairError('You are trying to sign data using generalized account without keypair')
       return Promise.resolve(sign(data, secrets.get(this).secretKey))
     },
-    address () {
+    address (this:Memory) {
       return Promise.resolve(secrets.get(this).publicKey)
     }
-  }
-})
+  } as Omit<Memory, 'isGa'|'options'>
+}) as stampit.Stamp<Memory>

--- a/src/account/memory.types.ts
+++ b/src/account/memory.types.ts
@@ -1,0 +1,17 @@
+import { AccountBase } from './base.types'
+/**
+ * In-memory account interface
+ * @alias module:@aeternity/aepp-sdk/es/account/memory
+ */
+export interface Memory extends AccountBase{
+  readonly options: {
+    keypair: {
+      publicKey: string;
+      secretKey: string;
+    };
+    gaId?: string;
+  };
+  isGa: boolean;
+  readonly sign: (data: string|Buffer) => Promise<Buffer|Uint8Array|String>;
+  readonly address: () => Promise<string>;
+}


### PR DESCRIPTION
This PR migrates `account/memory.ts` to TypeScript. It also fixes some eslint fixes in `base.ts`