### PR TITLE
feat(account): migrate account/multiple.js to TypeScript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "@types/bn.js": "^5.1.0",
         "@types/bs58": "^4.0.1",
         "@types/chai": "^4.3.0",
+        "@types/chai-as-promised": "^7.1.5",
         "@types/mocha": "^9.1.0",
         "@types/node": "^17.0.17",
         "@types/sha.js": "^2.4.0",
@@ -2725,6 +2726,15 @@
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.0.tgz",
       "integrity": "sha512-/ceqdqeRraGolFTcfoXNiqjyQhZzbINDngeoAq9GoHa8PPK1yNzTaxWjA6BFWp5Ua9JpXEMSS4s5i9tS0hOJtw==",
       "dev": true
+    },
+    "node_modules/@types/chai-as-promised": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/@types/chai-as-promised/-/chai-as-promised-7.1.5.tgz",
+      "integrity": "sha512-jStwss93SITGBwt/niYrkf2C+/1KTeZCZl1LaeezTlqppAKeoQC7jxyqYuP72sxBGKCIbw7oHgbYssIRzT5FCQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "*"
+      }
     },
     "node_modules/@types/eslint": {
       "version": "8.4.1",
@@ -13760,6 +13770,15 @@
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.0.tgz",
       "integrity": "sha512-/ceqdqeRraGolFTcfoXNiqjyQhZzbINDngeoAq9GoHa8PPK1yNzTaxWjA6BFWp5Ua9JpXEMSS4s5i9tS0hOJtw==",
       "dev": true
+    },
+    "@types/chai-as-promised": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/@types/chai-as-promised/-/chai-as-promised-7.1.5.tgz",
+      "integrity": "sha512-jStwss93SITGBwt/niYrkf2C+/1KTeZCZl1LaeezTlqppAKeoQC7jxyqYuP72sxBGKCIbw7oHgbYssIRzT5FCQ==",
+      "dev": true,
+      "requires": {
+        "@types/chai": "*"
+      }
     },
     "@types/eslint": {
       "version": "8.4.1",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "@types/bn.js": "^5.1.0",
     "@types/bs58": "^4.0.1",
     "@types/chai": "^4.3.0",
+    "@types/chai-as-promised": "^7.1.5",
     "@types/mocha": "^9.1.0",
     "@types/node": "^17.0.17",
     "@types/sha.js": "^2.4.0",

--- a/src/account/base.types.ts
+++ b/src/account/base.types.ts
@@ -1,46 +1,61 @@
 /**
-  * AccountBase
-  *
-  * Account is one of the three basic building blocks of an
-  * {@link module:@aeternity/aepp-sdk/es/ae--Ae} client and provides access to a
-  * signing key pair.
-  */
+ * AccountBase
+ *
+ * Account is one of the three basic building blocks of an
+ * {@link module:@aeternity/aepp-sdk/es/ae--Ae} client and provides access to a
+ * signing key pair.
+ */
 export interface AccountBase {
-    networkId: string
-    readonly signTransaction: (tx: string, opt?: { innerTx?: boolean }) => Promise<string>
-    /**
-     * Get network Id
-     * @instance
-     * @function getNetworkId
-     * @category async
-     * @rtype () => networkId: String
-     * @return {String} Network Id
-     */
-    readonly getNetworkId: (opt?: { networkId?: string, force?: boolean }) => string
-    readonly signMessage: (message: string, opt?: { returnHex?: boolean }) => Promise<string>
-    readonly verifyMessage: (message: string, signature: string,
-        opt?: { onAccount?: object }) => Promise<boolean>
+  networkId: string;
+  readonly signTransaction: (
+    tx: string,
+    opt?: { innerTx?: boolean }
+    ) => Promise<string>;
+  /**
+   * Get network Id
+   * @instance
+   * @function getNetworkId
+   * @category async
+   * @rtype () => networkId: String
+   * @return {String} Network Id
+   */
+  readonly getNetworkId: (opt?: {
+    networkId?: string;
+    force?: boolean;
+  }) => string;
+  readonly signMessage: (
+    message: string,
+    opt?: { returnHex?: boolean }
+  ) => Promise<string>;
+  readonly verifyMessage: (
+    message: string,
+    signature: string,
+    opt?: { onAccount?: object }
+  ) => Promise<boolean>;
 
-    /**
-     * Sign data blob
-     * @function sign
-     * @instance
-     * @abstract
-     * @category async
-     * @rtype (data: String) => data: Promise[String]
-     * @param {String} data - Data blob to sign
-     * @return {String} Signed data blob
-     */
-    readonly sign: (data: string | Buffer, opt?: any) => Promise<Buffer|Uint8Array|String>
+  /**
+   * Sign data blob
+   * @function sign
+   * @instance
+   * @abstract
+   * @category async
+   * @rtype (data: String) => data: Promise[String]
+   * @param {String} data - Data blob to sign
+   * @return {String} Signed data blob
+   */
+  readonly sign: (
+    data: string | Buffer,
+    opt?: any
+  ) => Promise<Buffer | Uint8Array | String>;
 
-    /**
-     * Obtain account address
-     * @function address
-     * @instance
-     * @abstract
-     * @category async
-     * @rtype () => address: Promise[String]
-     * @return {String} Public account address
-     */
-    readonly address: (opt?: object) => Promise<string>
+  /**
+   * Obtain account address
+   * @function address
+   * @instance
+   * @abstract
+   * @category async
+   * @rtype () => address: Promise[String]
+   * @return {String} Public account address
+   */
+  readonly address: (opt?: object) => Promise<string>;
 }

--- a/src/account/multiple.types.ts
+++ b/src/account/multiple.types.ts
@@ -1,0 +1,63 @@
+import { AccountBase } from './base.types'
+import { Memory } from './memory.types'
+
+export interface Multiple extends Memory {
+  readonly address: (this: Multiple, opts?:{onAccount?:string})=> Promise<string>;
+  readonly sign: (data:string | Buffer,
+    opts?:{onAccount?:string})=> Promise<Buffer|Uint8Array>;
+  accounts: AccountBase[];
+  selectedAddress?: string;
+
+  /**
+   * Get accounts addresses
+   * @alias module:@aeternity/aepp-sdk/es/accounts/multiple
+   * @function
+   * @rtype () => String[]
+   * @return {String[]}
+   * @example addresses()
+   */
+  readonly addresses: () => string[];
+
+  /**
+   * Add specific account
+   * @alias module:@aeternity/aepp-sdk/es/accounts/multiple
+   * @function
+   * @category async
+   * @rtype (account: Account, { select: Boolean }) => void
+   * @param {Object} account - Account instance
+   * @param {Object} [options={}] - Options
+   * @param {Boolean} [options.select] - Select account
+   * @return {void}
+   * @example addAccount(account)
+   */
+  readonly addAccount: (account: AccountBase, { select }: { select?: boolean }) => Promise<void>;
+
+  /**
+   * Remove specific account
+   * @alias module:@aeternity/aepp-sdk/es/accounts/multiple
+   * @function
+   * @rtype (address: String) => void
+   * @param {String} address - Address of account to remove
+   * @return {void}
+   * @example removeAccount(address)
+   */
+  readonly removeAccount: (address: string) => void;
+
+  /**
+   * Select specific account
+   * @alias module:@aeternity/aepp-sdk/es/account/selector
+   * @instance
+   * @rtype (address: String) => void
+   * @param {String} address - Address of account to select
+   * @example selectAccount('ak_xxxxxxxx')
+   */
+  readonly selectAccount: (address: string) => void;
+
+  /**
+   * Resolves an account
+   * @param account account address (should exist in sdk instance), MemoryAccount or keypair
+   * @returns {AccountBase}
+   * @private
+   */
+  readonly _resolveAccount:(account: string | AccountBase)=> AccountBase;
+}

--- a/test/integration/accounts.ts
+++ b/test/integration/accounts.ts
@@ -17,7 +17,7 @@
 
 import { describe, it, before } from 'mocha'
 import { expect } from 'chai'
-import { getSdk, BaseAe, networkId } from './'
+import { getSdk, BaseAe, networkId } from '.'
 import { generateKeyPair } from '../../src/utils/crypto'
 import BigNumber from 'bignumber.js'
 import MemoryAccount from '../../src/account/memory'
@@ -148,8 +148,8 @@ describe('Accounts', function () {
     const accountBeforeSpendByHash = await aeSdk.getAccount(
       await aeSdk.address(), { height: spend.blockHeight - 1 }
     )
-    BigNumber(accountBeforeSpendByHash.balance)
-      .minus(BigNumber(accountAfterSpend.balance))
+    new BigNumber(accountBeforeSpendByHash.balance)
+      .minus(new BigNumber(accountAfterSpend.balance))
       .toString()
       .should.be
       .equal(`${spend.tx.fee + spend.tx.amount}`)


### PR DESCRIPTION
Migrates `account/multiple.js` to TypeScript. Also adds types through npm for chai (`types/chai-as-promised`). Finally, it migrates the account integration test to TypeScript.